### PR TITLE
Refactor exception

### DIFF
--- a/include/latte_core_event.hpp
+++ b/include/latte_core_event.hpp
@@ -6,9 +6,16 @@ namespace core {
 namespace event {
 
 enum latte_event {
+  describe_event_init,
   describe_event_test_start,
+  describe_event_test_incremental_result,
   describe_event_test_result,
-  describe_event_test_end
+  describe_event_test_end,
+
+  it_event_init,
+  it_event_test_start,
+  it_event_test_result,
+  it_event_test_end,
 };
 
 emitter::latte_event_emitter latte_it_emitter;

--- a/include/latte_core_exception.hpp
+++ b/include/latte_core_exception.hpp
@@ -9,15 +9,43 @@ namespace core {
 namespace exception {
 
 struct latte_exception {
-  latte_exception(const std::string& message, bool errored = false)
-      : message_(message)
-      , errored_(errored) {}
+  latte_exception() {};
+  latte_exception(const std::string& actual, const std::string& expected, const std::string& message, bool errored = false) :
+      actual_(actual),
+      expected_(expected),
+      message_(message), errored_(errored) {}
+
+  latte_exception(const latte_exception& other) {
+    this->actual_ = other.actual_;
+    this->expected_ = other.expected_;
+    this->message_ = other.message_;
+    this->errored_ = other.errored_;
+  }
+
+  latte_exception& operator= (const latte_exception& other) {
+    this->actual_ = other.actual_;
+    this->expected_ = other.expected_;
+    this->message_ = other.message_;
+    this->errored_ = other.errored_;
+    return *this;
+  }
+
   const std::string what() const noexcept { return message_; }
+
   bool has_errored() const {
     return errored_;
   }
 
+  std::string actual() {
+    return actual_;
+  }
+  std::string expected() {
+    return expected_;
+  }
+
   private:
+  std::string actual_;
+  std::string expected_;
   std::string message_;
   bool errored_ = false;
 };

--- a/include/latte_core_result.hpp
+++ b/include/latte_core_result.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 #include <tuple>
+#include "latte_core_exception.hpp"
 namespace latte {
 namespace core {
 
@@ -30,23 +31,23 @@ struct latte_it_result {
   latte_it_result(const latte_it_result& other) {
     this->state_ = other.state_;
     this->description_ = other.description_;
-    this->message_ = other.message_;
+    this->error_ = other.error_;
     this->depth_string_ = other.depth_string_;
   }
 
   latte_it_result(const std::string& description) :
       description_(description){};
 
-  latte_it_result(const std::string& description, const std::string& message) :
-      latte_it_result(description, message, latte_result_state::pending){};
+  latte_it_result(const std::string& description, const exception::latte_exception& error) :
+      latte_it_result(description, error, latte_result_state::pending){};
 
-  latte_it_result(const std::string& description, const std::string& message, latte_result_state state) :
-      description_(description), message_(message), state_(state){};
+  latte_it_result(const std::string& description, const exception::latte_exception& error, latte_result_state state) :
+      description_(description), error_(error), state_(state){};
 
   latte_it_result& operator=(const latte_it_result& other) {
     this->state_ = other.state_;
     this->description_ = other.description_;
-    this->message_ = other.message_;
+    this->error_ = other.error_;
     this->depth_string_ = other.depth_string_;
     this->time_ = other.time_;
     return *this;
@@ -64,8 +65,8 @@ struct latte_it_result {
     return description_;
   }
 
-  const std::string message() {
-    return message_;
+  const exception::latte_exception error() {
+    return error_;
   }
 
   bool is_passing() {
@@ -89,7 +90,7 @@ struct latte_it_result {
 
   private:
   std::string description_ = "";
-  std::string message_ = "";
+  exception::latte_exception error_;
   latte_result_state state_;
   std::string depth_string_ = "";
   double time_ = 0;
@@ -124,11 +125,11 @@ struct latte_describe_result {
     results_.push_back(result);
   }
   void add_result(const std::string& description, latte_result_state state) {
-    add_result(description, "", state);
+    add_result(description, exception::latte_exception(), state);
   }
 
-  void add_result(const std::string& description, const std::string& message, latte_result_state state) {
-    auto result = std::make_shared<latte_it_result>(description, message, state);
+  void add_result(const std::string& description, const exception::latte_exception error, latte_result_state state) {
+    auto result = std::make_shared<latte_it_result>(description, error, state);
     results_.push_back(result);
   }
 

--- a/include/latte_type.hpp
+++ b/include/latte_type.hpp
@@ -12,7 +12,10 @@ template <typename T, typename U>
 using latte_comparator_callback = std::function<bool(T, U)>;
 
 template <typename T>
-using latte_result_t = std::list<std::shared_ptr<T>>;
+using latte_results_t = std::list<std::shared_ptr<T>>;
+
+template <typename T>
+using latte_result_t = std::shared_ptr<T>;
 
 template <class T>
 struct is_integer_

--- a/include/reporter/reporter.hpp
+++ b/include/reporter/reporter.hpp
@@ -1,13 +1,16 @@
 #ifndef LATTE_REPORTER_H
 #define LATTE_REPORTER_H
 #include "spec.hpp"
+#include "tap.hpp"
 #include <thread>
 namespace latte {
 namespace reporter {
 struct latte_reporter {
   void operator()() {
-    reporter_spec spec;
-    spec();
+    // reporter_spec spec;
+    // spec();
+    reporter_tap tap;
+    tap();
   }
 };
 }

--- a/include/reporter/spec.hpp
+++ b/include/reporter/spec.hpp
@@ -20,7 +20,7 @@ using namespace latte::color;
 using latte::core::debug;
 using latte::core::latte_describe_result;
 using latte::core::latte_result_state;
-using describe_result_t = latte::type::latte_result_t<latte_describe_result>;
+using describe_results_t = latte::type::latte_results_t<latte_describe_result>;
 }
 
 namespace latte {
@@ -32,14 +32,14 @@ struct reporter_spec {
   void operator()() {
     latte_describe_emitter.on(
       describe_event_test_result,
-      std::function<void(describe_result_t)>(process_test_suite));
+      std::function<void(describe_results_t)>(process_test_suite));
 
     latte_describe_emitter.on(
       describe_event_test_end,
-      std::function<void(describe_result_t)>(process_completed));
+      std::function<void(describe_results_t)>(process_completed));
   }
 
-  static void process_test_suite(describe_result_t current_test_suite) {
+  static void process_test_suite(describe_results_t current_test_suite) {
     auto test_suite = current_test_suite.front();
     auto describe_description = test_suite->description();
     std::cout << test_suite->depth_string() + white(describe_description) << std::endl;
@@ -62,10 +62,10 @@ struct reporter_spec {
     }
   }
 
-  static void process_completed(describe_result_t test_suites) {
-    describe_result_t passing_test_suites;
-    describe_result_t failing_test_suites;
-    describe_result_t pending_test_suites;
+  static void process_completed(describe_results_t test_suites) {
+    describe_results_t passing_test_suites;
+    describe_results_t failing_test_suites;
+    describe_results_t pending_test_suites;
     int marker_count = 0;
     int passing_count = 0;
     int failing_count = 0;
@@ -99,7 +99,7 @@ struct reporter_spec {
       for (auto test_suite : failing_test_suites) {
         int failed_count = 0;
         for (auto test_case : test_suite->results()) {
-          debug(white(std::to_string(failed_count) + ") " + test_case->description()) + " : " + red(test_case->message()) + "\n");
+          debug(white(std::to_string(failed_count) + ") " + test_case->description()) + " : " + red(test_case->error().what()) + "\n");
           failed_count++;
         }
       }

--- a/include/style/expect.hpp
+++ b/include/style/expect.hpp
@@ -33,6 +33,8 @@ struct expect_t {
   expect_t* equal(T expected) {
     bool result = core::comparator::latte_comparator<type_t<T>, type_t<T>>().equal(this->actual, expected);
     this->eval(
+      to_string(this->actual),
+      to_string(expected),
       result,
       "Expected " + to_string(this->actual) + " to " + (this->negate ? "not " : "") + "equal " + to_string(expected)
     );
@@ -54,6 +56,8 @@ struct expect_t {
   expect_t* equal(U expected) {
     bool result = core::comparator::latte_comparator<type_t<T>, type_t<U>>().equal(this->actual, expected);
     this->eval(
+      to_string(this->actual),
+      to_string(expected),
       result,
       "Expected " + to_string(this->actual) + " to " + (this->negate ? "not " : "") + "equal " + to_string(expected)
     );
@@ -76,6 +80,8 @@ struct expect_t {
   expect_t* equal(U expected, const core::comparator::latte_comparator<T, U>& comparator) {
     bool result = comparator.equal(this->actual, expected);
     this->eval(
+      to_string(this->actual),
+      to_string(expected),
       result,
       "Expected " + to_string(this->actual) + " to " + (this->negate ? "not " : "") + "equal " + to_string(expected)
     );
@@ -98,6 +104,8 @@ struct expect_t {
   expect_t* equal(U expected, const type::latte_comparator_callback<T, U>& comparator) {
     bool result = comparator(this->actual, expected);
     this->eval(
+      to_string(this->actual),
+      to_string(expected),
       result,
       "Expected " + to_string(this->actual) + " to " + (this->negate ? "not " : "") + "equal " + to_string(expected)
     );
@@ -329,6 +337,8 @@ struct expect_t {
   expect_t* strict_equal(T expected) {
     bool result = core::comparator::latte_comparator<type_t<T>, type_t<T>>().strict_equal(this->actual, expected);
     this->eval(
+      to_string(this->actual),
+      to_string(expected),
       result,
       "Expected " + to_string(this->actual) + " to strictly " + (this->negate ? "not " : "") + "equal " + to_string(expected)
     );
@@ -358,6 +368,8 @@ struct expect_t {
     bool result = core::comparator::latte_comparator<type_t<T>, type_t<U>>().strict_equal(this->actual, expected);
     // bool is_same_type = std::is_same<decltype(this->actual), decltype(expected)>::value;
     this->eval(
+      to_string(this->actual),
+      to_string(expected),
       result,
       "Expected " + to_string(this->actual) + " to strictly " + (this->negate ? "not " : "") + "equal " + to_string(expected)
     );
@@ -380,6 +392,8 @@ struct expect_t {
   expect_t* strict_equal(U expected, const core::comparator::latte_comparator<T, U>& comparator) {
     bool result = comparator.strict_equal(this->actual, expected);
     this->eval(
+      to_string(this->actual),
+      to_string(expected),
       result,
       "Expected " + to_string(this->actual) + " to strictly" + (this->negate ? "not " : "") + "equal " + to_string(expected)
     );
@@ -403,6 +417,8 @@ struct expect_t {
   expect_t* strict_equal(U expected, const type::latte_comparator_callback<T, U>& comparator) {
     bool result = comparator(this->actual, expected);
     this->eval(
+      to_string(this->actual),
+      to_string(expected),
       result,
       "Expected " + to_string(this->actual) + " to strictly" + (this->negate ? "not " : "") + "equal " + to_string(expected)
     );
@@ -635,6 +651,8 @@ struct expect_t {
 
   expect_t* close_to(double expected, double tolerance) {
     this->eval(
+      to_string(this->actual),
+      "close to " + to_string(expected),
       fabs(this->actual - expected) <= tolerance,
       "Expected " + to_string(this->actual) + " to " + (this->negate ? "not " : "") + "equal " + (to_string(expected) + " within tolerance of " + to_string(tolerance))
     );
@@ -644,6 +662,8 @@ struct expect_t {
 
   expect_t* within(double lower, double upper) {
     this->eval(
+      to_string(this->actual),
+      "within " + to_string(lower) + " and " + to_string(upper),
       this->actual > lower && this->actual < upper,
       "Expected " + to_string(this->actual) + " to " + (this->negate ? "not " : "") + "be above " + to_string(lower) + " and below " + to_string(upper)
     );
@@ -654,6 +674,8 @@ struct expect_t {
 
   expect_t* above(double expected) {
     this->eval(
+      to_string(this->actual),
+      to_string(expected),
       this->actual > expected,
       "Expected " + to_string(this->actual) + " to " + (this->negate ? "not " : "") + "be greater than " + to_string(expected)
     );
@@ -669,6 +691,8 @@ struct expect_t {
 
   expect_t* least(double expected) {
     this->eval(
+      to_string(this->actual),
+      to_string(expected),
       this->actual >= expected,
       "Expected " + to_string(this->actual) + " to " + (this->negate ? "not " : "") + "be greater than or equal to " + to_string(expected)
     );
@@ -681,6 +705,8 @@ struct expect_t {
 
   expect_t* below(double expected) {
     this->eval(
+      to_string(this->actual),
+      to_string(expected),
       this->actual < expected,
       "Expected " + to_string(this->actual) + " to " + (this->negate ? "not " : "") + "be lesser than " + to_string(expected)
     );
@@ -698,6 +724,8 @@ struct expect_t {
 
   expect_t* most(double expected) {
     this->eval(
+      to_string(this->actual),
+      to_string(expected),
       this->actual <= expected,
       "Expected " + to_string(this->actual) + " to " + (this->negate ? "not " : "") + "be less than or equal to " + to_string(expected)
     );
@@ -717,8 +745,10 @@ struct expect_t {
     );
   };
 
-  expect_t* satisfy(bool result, std::string message) {
+  expect_t* satisfy(bool result, std::string actual, std::string expected, std::string message) {
     this->eval(
+      actual,
+      expected,
       result,
       message
     );
@@ -786,12 +816,12 @@ struct expect_t {
     T actual;
     bool negate = false;
 
-    void eval(bool result, const std::string& message) {
+    void eval(std::string actual, std::string expected, bool result, const std::string& message) {
       bool did_pass = (this->negate ? !result : result);
       // Reset the flag
       this->negate = false;
       if (!did_pass) {
-        throw core::exception::latte_exception { message, did_pass };
+        throw core::exception::latte_exception { actual, expected, message, did_pass };
       }
     };
 


### PR DESCRIPTION
* Errors are now passed along with results.
* Additional events are emitted by `describe()` and `it()`.